### PR TITLE
fix duplicated code entries for in transaction self destruct

### DIFF
--- a/src/ethereum/forks/amsterdam/block_access_lists/builder.py
+++ b/src/ethereum/forks/amsterdam/block_access_lists/builder.py
@@ -308,6 +308,20 @@ def add_code_change(
     """
     ensure_account(builder, address)
 
+    # Check if we already have a code change for this block_access_index
+    # This handles the case of in-transaction selfdestructs where code is
+    # first deployed and then cleared in the same transaction
+    existing_changes = builder.accounts[address].code_changes
+    for i, existing in enumerate(existing_changes):
+        if existing.block_access_index == block_access_index:
+            # Replace the existing code change with the new one
+            # For selfdestructs, this ensures we only record the final state (empty code)
+            existing_changes[i] = CodeChange(
+                block_access_index=block_access_index, new_code=new_code
+            )
+            return
+
+    # No existing change for this block_access_index, add a new one
     change = CodeChange(
         block_access_index=block_access_index, new_code=new_code
     )


### PR DESCRIPTION
### What was wrong?

Related to Issue https://github.com/ethereum/execution-spec-tests/pull/2159

### How was it fixed?

Ensure code is overwritten by later changes