### PR TITLE
fix non-tracked 7702 authority for invalid delegations

### DIFF
--- a/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
+++ b/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
@@ -13,7 +13,7 @@ from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import keccak256
 from ethereum.exceptions import InvalidBlock, InvalidSignatureError
 
-from ..block_access_lists import track_address_access
+from ..block_access_lists.tracker import track_address_access
 from ..fork_types import Address, Authorization
 from ..state import account_exists, get_account, increment_nonce, set_code
 from ..utils.hexadecimal import hex_to_address

--- a/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
+++ b/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
@@ -132,6 +132,10 @@ def access_delegation(
         The delegation address, code, and access gas cost.
     """
     state = evm.message.block_env.state
+
+    # EIP-7928: Track the authority address (delegated account being called)
+    track_address_access(state.change_tracker, address)
+
     code = get_account(state, address).code
     if not is_valid_delegation(code):
         return False, address, code, Uint(0)
@@ -143,6 +147,10 @@ def access_delegation(
         evm.accessed_addresses.add(address)
         access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
     code = get_account(state, address).code
+
+    # EIP-7928: Track delegation target when loaded as call target
+    # `address` here is now the delegation target account
+    track_address_access(state.change_tracker, address)
 
     return True, address, code, access_gas_cost
 

--- a/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
+++ b/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
@@ -13,6 +13,7 @@ from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import keccak256
 from ethereum.exceptions import InvalidBlock, InvalidSignatureError
 
+from ..block_access_lists import track_address_access
 from ..fork_types import Address, Authorization
 from ..state import account_exists, get_account, increment_nonce, set_code
 from ..utils.hexadecimal import hex_to_address
@@ -180,6 +181,9 @@ def set_delegation(message: Message) -> U256:
 
         authority_account = get_account(state, authority)
         authority_code = authority_account.code
+        
+        # EIP-7928: Track authority account access in BAL even if delegation fails
+        track_address_access(state.change_tracker, authority)
 
         if authority_code and not is_valid_delegation(authority_code):
             continue

--- a/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
+++ b/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
@@ -181,8 +181,9 @@ def set_delegation(message: Message) -> U256:
 
         authority_account = get_account(state, authority)
         authority_code = authority_account.code
-        
-        # EIP-7928: Track authority account access in BAL even if delegation fails
+
+        # EIP-7928: Track authority account access in BAL even if delegation
+        # fails
         track_address_access(state.change_tracker, authority)
 
         if authority_code and not is_valid_delegation(authority_code):

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -494,10 +494,6 @@ def callcode(evm: Evm) -> None:
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
-    track_address_access(
-        evm.message.block_env.state.change_tracker, code_address
-    )
-
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
@@ -635,10 +631,6 @@ def delegatecall(evm: Evm) -> None:
         U256(0), gas, Uint(evm.gas_left), extend_memory.cost, access_gas_cost
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
-
-    track_address_access(
-        evm.message.block_env.state.change_tracker, code_address
-    )
 
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -139,6 +139,12 @@ def process_message_call(message: Message) -> MessageCallOutput:
             message.code = get_account(block_env.state, delegated_address).code
             message.code_address = delegated_address
 
+            # EIP-7928: Track delegation target when loaded as call target
+            track_address_access(
+                block_env.state.change_tracker,
+                delegated_address,
+            )
+
         evm = process_message(message)
 
     if evm.error:


### PR DESCRIPTION
### What was wrong?

Related to Issue https://github.com/fselmo/execution-specs/issues/15

### How was it fixed?

Track authority early, right after the actual state read

Test Case:
https://github.com/ethereum/execution-spec-tests/pull/2212#discussion_r2398166447