### PR TITLE
refactor: Put back explicit acct tracking outside of 7702 delegation path

### DIFF
--- a/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
+++ b/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
@@ -133,12 +133,12 @@ def access_delegation(
     """
     state = evm.message.block_env.state
 
-    # EIP-7928: Track the authority address (delegated account being called)
-    track_address_access(state.change_tracker, address)
-
     code = get_account(state, address).code
     if not is_valid_delegation(code):
         return False, address, code, Uint(0)
+
+    # EIP-7928: Track the authority address (delegated account being called)
+    track_address_access(state.change_tracker, address)
 
     address = Address(code[EOA_DELEGATION_MARKER_LENGTH:])
     if address in evm.accessed_addresses:
@@ -149,7 +149,6 @@ def access_delegation(
     code = get_account(state, address).code
 
     # EIP-7928: Track delegation target when loaded as call target
-    # `address` here is now the delegation target account
     track_address_access(state.change_tracker, address)
 
     return True, address, code, access_gas_cost

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -494,6 +494,10 @@ def callcode(evm: Evm) -> None:
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
+    track_address_access(
+        evm.message.block_env.state.change_tracker, code_address
+    )
+
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
@@ -631,6 +635,10 @@ def delegatecall(evm: Evm) -> None:
         U256(0), gas, Uint(evm.gas_left), extend_memory.cost, access_gas_cost
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
+
+    track_address_access(
+        evm.message.block_env.state.change_tracker, code_address
+    )
 
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by


### PR DESCRIPTION
### What was wrong?

Nothing is "wrong" and currently we pass all tests. However, the explicitness with which accounts are tracked within `CALLCODE` and `DELEGATECALL` was removed by me in the commit below. It was still tracked because the `access_delegation` would track the address before it checked if it was a delegation or not, so it would always track the address.

For the specs, this needs to be more explicit. The only missing piece of the commit below was tracking the delegation target after it was accessed. This puts everything back to the way it should be imo for a reader of the specs.

Related to commit 67404acd7e78ad6be6d858895d900e78f975fff7

cc: @nerolation

### How was it fixed?

- Put back explicit account tracking inside `CALLCODE` and `DELEGATECALL`.
- Only track the address within `access_delegation` if it passes the `is_valid_delegation(...)` check.

#### Cute Animal Picture

Picture of my across-the-street neighbor's house, middle of the day, the other day 😅 

<img width="707" height="665" alt="Screenshot 2025-10-09 at 09 22 13" src="https://github.com/user-attachments/assets/598d8fc8-2aef-4ff5-a9c8-ec22e7373e70" />

