### PR TITLE
fix: track implicit SLOAD within SSTORE for OOG cases

### DIFF
--- a/src/ethereum/forks/amsterdam/vm/instructions/storage.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/storage.py
@@ -100,6 +100,15 @@ def sstore(evm: Evm) -> None:
     )
     current_value = get_storage(state, evm.message.current_target, key)
 
+    # Track the implicit SLOAD that occurs in SSTORE
+    # This must happen BEFORE charge_gas() so reads are recorded even if OOG
+    track_storage_read(
+        state.change_tracker,
+        evm.message.current_target,
+        key,
+        evm.message.block_env.state,
+    )
+
     gas_cost = Uint(0)
 
     if (evm.message.current_target, key) not in evm.accessed_storage_keys:


### PR DESCRIPTION
### What was wrong?

Track implicit SLOAD within SSTORE. See EthR&D conversation [here](https://discord.com/channels/595666850260713488/1364000387195076608/1427168501088653363) for context.

Tests were updated for boundary checks around EIP-2200 stipend and subsequent implicit SLOAD here: ethereum/execution-spec-tests#2297. These tests all fill after the change in this PR.

#### Cute Animal Picture

`o_0`
