### PR TITLE
fix: do not track setting empty code to a new account

### DIFF
--- a/src/ethereum/forks/amsterdam/state.py
+++ b/src/ethereum/forks/amsterdam/state.py
@@ -604,7 +604,12 @@ def set_code(state: State, address: Address, code: Bytes) -> None:
 
     modify_state(state, address, write_code)
 
-    track_code_change(state.change_tracker, address, code)
+    # Only track code changes if it's not setting empty code on a
+    # newly created address. For newly created addresses, setting
+    # code to b"" is not a meaningful state change since the address
+    # had no code to begin with.
+    if not (code == b"" and address in state.created_accounts):
+        track_code_change(state.change_tracker, address, code)
 
 
 def get_storage_original(state: State, address: Address, key: Bytes32) -> U256:


### PR DESCRIPTION
### What was wrong?

For accounts created within the call frame, we were tracking a code change of `"0x"` for the bal index of the transaction that created the account. We shouldn't track the change unless the code is non-zero because a non-existent account already has "0x" (`b""`) code.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fwww.jessleephotos.com%2Fimages%2Fxl%2FAlaska-Brown-Bear-.jpg&f=1&nofb=1&ipt=e121815c6d0baf268c395cbd92111c8a0ec74932f4f7155a1f09138a0b901802)
