### PR TITLE
fix: track coinbase with no changes for zero rewards

### DIFF
--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -36,6 +36,7 @@ from .block_access_lists.tracker import (
     finalize_transaction_changes,
     handle_in_transaction_selfdestruct,
     set_block_access_index,
+    track_address_access,
     track_balance_change,
 )
 from .blocks import Block, Header, Log, Receipt, Withdrawal, encode_receipt
@@ -988,6 +989,11 @@ def process_transaction(
     coinbase_balance_after_mining_fee = get_account(
         block_env.state, block_env.coinbase
     ).balance + U256(transaction_fee)
+
+    # EIP-7928: Track coinbase in BAL even when transaction_fee is 0
+    # The coinbase is accessed during fee calculation, so must appear in BAL
+    track_address_access(block_env.state.change_tracker, block_env.coinbase)
+
     if coinbase_balance_after_mining_fee != 0:
         set_account_balance(
             block_env.state,


### PR DESCRIPTION
### What was wrong?

Track the coinbase with no changes if it receives a `0` block reward. See conversation [here](https://discord.com/channels/595666850260713488/1364000387195076608/1428161161672523927) for more details. This brings the specs up-to-date with the EIP changes introduced [here](https://github.com/ethereum/EIPs/pull/10527/files#diff-b4ae44357044a8606fc10a6d8433e1ee2135b1111042c88876bd58d6f11c1d6dR172).


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse4.mm.bing.net%2Fth%2Fid%2FOIP.qDIODcN5vttEghM70e530wHaH9%3Fcb%3D12%26pid%3DApi&f=1&ipt=45c5c4368e65fcd313c06ac188498286f85650128826447c032431066a1ac54e&ipo=images)
