### PR TITLE
ensure coinbase appears in BAL for zero-tip transactions

### DIFF
--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -1000,13 +1000,17 @@ def process_transaction(
     coinbase_balance_after_mining_fee = get_account(
         block_env.state, block_env.coinbase
     ).balance + U256(transaction_fee)
-    if coinbase_balance_after_mining_fee != 0:
-        set_account_balance(
-            block_env.state,
-            block_env.coinbase,
-            coinbase_balance_after_mining_fee,
-        )
-    elif account_exists_and_is_empty(block_env.state, block_env.coinbase):
+
+    # Always set coinbase balance to ensure proper tracking
+    set_account_balance(
+        block_env.state,
+        block_env.coinbase,
+        coinbase_balance_after_mining_fee,
+    )
+
+    if coinbase_balance_after_mining_fee == 0 and account_exists_and_is_empty(
+        block_env.state, block_env.coinbase
+    ):
         destroy_account(block_env.state, block_env.coinbase)
 
     for address in tx_output.accounts_to_delete:


### PR DESCRIPTION
Fixes https://github.com/fselmo/execution-specs/issues/24

Always call set_account_balance for coinbase regardless of transaction fee to ensure proper BAL tracking. The finalize_transaction_changes function filters spurious balance changes, leaving coinbase with empty changes when tip is zero.

cc @fselmo 